### PR TITLE
Update/recipient parser

### DIFF
--- a/__tests__/adapters/pagarme/address.unit.js
+++ b/__tests__/adapters/pagarme/address.unit.js
@@ -2,10 +2,10 @@ const addressAdapter = require('../../../src/adapters/pagarme/address')
 
 const addressMock = {
   neighborhood: 'bairro',
-  street: 'rua',
-  street_number: '240',
+  street: '  rua  ',
+  street_number: '240   ',
   zipcode: '04571020',
-  complementary: 'complemento',
+  complementary: 'complemento ',
   state: 'PA',
   city: 'Belém',
 }

--- a/__tests__/adapters/pagarme/recipient.unit.js
+++ b/__tests__/adapters/pagarme/recipient.unit.js
@@ -42,7 +42,6 @@ const companyRecipient = {
         street: 'outra rua',
         street_number: '241',
         zipcode: '04571020',
-        complementary: 'foo complemento',
         state: 'SP',
         city: 'foo cidade',
       }],
@@ -312,7 +311,7 @@ const individualRecipient = {
       street: 'Rua Doutor Télio Barreto',
       street_number: '240',
       zipcode: '04571020',
-      complementary: 'Apt 202',
+      complementary: 'SALAO DE USO COMERCIAL N 517, NO 5 PISO DO SHOPPING CENTER PIRA CICABA',
       state: 'RJ',
       city: 'Macaé',
     },
@@ -553,7 +552,7 @@ test('the adapter must return a fulfilled adresses array object for a company re
   expect(address3).toHaveProperty('streetName', 'outra rua')
   expect(address3).toHaveProperty('entranceNumber', '241')
   expect(address3).toHaveProperty('neighborhood', 'foo bairro')
-  expect(address3).toHaveProperty('complement', 'foo complemento')
+  expect(address3).toHaveProperty('complement', undefined)
   expect(address3).toHaveProperty('cityName', 'foo cidade')
   expect(address3).toHaveProperty('countrySubdivisionCode', 'SP')
   expect(address3).toHaveProperty('countryId', 76)
@@ -606,7 +605,7 @@ test('the adapter must return a fulfilled adresses array object for a individual
   expect(address).toHaveProperty('streetName', 'Rua Doutor Télio Barreto')
   expect(address).toHaveProperty('entranceNumber', '240')
   expect(address).toHaveProperty('neighborhood', 'Miramar')
-  expect(address).toHaveProperty('complement', 'Apt 202')
+  expect(address).toHaveProperty('complement', 'SALAO DE USO COMERCIAL N 517, NO 5 PISO DO SHOPPING CENTER PIRA')
   expect(address).toHaveProperty('cityName', 'Macaé')
   expect(address).toHaveProperty('countrySubdivisionCode', 'RJ')
   expect(address).toHaveProperty('countryId', 76)

--- a/__tests__/adapters/pagarme/recipient.unit.js
+++ b/__tests__/adapters/pagarme/recipient.unit.js
@@ -11,7 +11,7 @@ const companyRecipient = {
     type: 'corporation',
     document_number: '43633675456',
     company_name: 'Full Name Company',
-    trading_name: 'Company Trading Name',
+    trading_name: 'Com\\pany Tra||ding Nam\ne',
     cnae: '9999-9/99',
     phone_numbers: [Object],
     corporation_type: 'ltda',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadu",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A JavaScript library to interface with CADU",
   "main": "src/client.js",
   "unpkg": "dist/cadu.min.js",

--- a/src/adapters/pagarme/address.js
+++ b/src/adapters/pagarme/address.js
@@ -5,25 +5,31 @@ const {
   pipe,
   prop,
   slice,
+  trim,
   when,
 } = require('ramda')
 
 const isString = is(String)
 
+const propAndTrim = propName => pipe(
+  prop(propName),
+  when(isString, trim)
+)
+
 const complement = pipe(
-  prop('complementary'),
+  propAndTrim('complementary'),
   when(isString, slice(0, 63))
 )
 
 const adapter = applySpec({
   typeId: always(2),
-  streetName: prop('street'),
-  entranceNumber: prop('street_number'),
-  neighborhood: prop('neighborhood'),
-  postalCode: prop('zipcode'),
+  streetName: propAndTrim('street'),
+  entranceNumber: propAndTrim('street_number'),
+  neighborhood: propAndTrim('neighborhood'),
+  postalCode: propAndTrim('zipcode'),
   complement,
-  cityName: prop('city'),
-  countrySubdivisionCode: prop('state'),
+  cityName: propAndTrim('city'),
+  countrySubdivisionCode: propAndTrim('state'),
   countryId: always(76),
 })
 

--- a/src/adapters/pagarme/address.js
+++ b/src/adapters/pagarme/address.js
@@ -1,4 +1,19 @@
-const { applySpec, prop, always } = require('ramda')
+const {
+  always,
+  applySpec,
+  is,
+  pipe,
+  prop,
+  slice,
+  when,
+} = require('ramda')
+
+const isString = is(String)
+
+const complement = pipe(
+  prop('complementary'),
+  when(isString, slice(0, 63))
+)
 
 const adapter = applySpec({
   typeId: always(2),
@@ -6,7 +21,7 @@ const adapter = applySpec({
   entranceNumber: prop('street_number'),
   neighborhood: prop('neighborhood'),
   postalCode: prop('zipcode'),
-  complement: prop('complementary'),
+  complement,
   cityName: prop('city'),
   countrySubdivisionCode: prop('state'),
   countryId: always(76),

--- a/src/adapters/pagarme/recipient.js
+++ b/src/adapters/pagarme/recipient.js
@@ -6,6 +6,7 @@ const {
   anyPass,
   applySpec,
   complement,
+  evolve,
   filter,
   has,
   ifElse,
@@ -19,6 +20,7 @@ const {
   pipe,
   prop,
   reject,
+  replace,
   uniq,
   __,
 } = require('ramda')
@@ -133,9 +135,18 @@ const recipient = applySpec({
 
 const rejectNullOrEmpty = reject(isNil)
 
+const caduUnsafeCharsReg = /[\\|\n]/g
+const replaceUnsafeChars = replace(caduUnsafeCharsReg, '')
+
+const parseRecipient = evolve({
+  legalName: replaceUnsafeChars,
+  tradeName: replaceUnsafeChars,
+})
+
 module.exports = pipe(
   rejectNullOrEmpty,
   recipient,
   filterNotEmpty,
-  filterNotNil
+  filterNotNil,
+  parseRecipient
 )


### PR DESCRIPTION
# Descrição

Conforme detalhado na issue https://github.com/pagarme/credenciamento/issues/486, tivemos um problema relacionado ao número de caracteres que é enviado para o cadU na propriedade `complemento` do endereço. O limit máximo aceito pelo cadU é de 64 caracteres, e, houve um cliente que preencheu o campo complementou com 78 caracteres.

Este PR também aproveita para lidar com a remoção de caracteres invalidos que os clientes ocasionalmente enviam no campo `Razão Social` (https://github.com/pagarme/credenciamento/issues/372). Apesar de este erro já ter sido tratado no core, faz sentido mover essa responsabilidade para o `cadu-js` que faz a interface com o cadU.

Por fim, também é adicionado a operação `trim` em todos os campos do endereço.  O cadU não aceita espaços nos campos do endereço, caso exista, a análise será falha e alguém irá precisar ajustar o endereço do recebedor manualmente e depois reenviar a análise. Infelizmente vimos que este é um erro comum quando o usuário está inputando o endereço, e, visto que iremos realizar a integração com plataformas parceiras, é importante realizarmos essa remoção no cadu-js. Desta forma, este PR adiciona o `trim` nas propriedades do endereço para garantir que não haverá espaço no começo ou fim.

## Checklist

- [x] Limita o número de caracteres de complementou para 63 caracteres.
- [x] Remove caracteres considerados inseguros pelo [time do cadU](https://pagarme.slack.com/?redir=%2Farchives%2FCNHRJ2820%2Fp1575574975179600) nas propriedades `legalName` e `tradeName`.
- [x] Realiza o trim de todas as propriedades do endereço.